### PR TITLE
Update moveall for python3 compatibility

### DIFF
--- a/beetsplug/moveall.py
+++ b/beetsplug/moveall.py
@@ -35,23 +35,23 @@ def handle_item_moved(source, destination, **_kwargs):
 
 
 def handle_cli_exit(lib, **_kwargs):
-    for src_dir, dst_dir in directories_moved.iteritems():
+    for src_dir, dst_dir in directories_moved.items():
         if dst_dir is MULTIPLE_DESTS:
-            print ("moves out of %s have multiple dests, will not moveall" %
-                   (src_dir,))
+            print("moves out of %s have multiple dests, will not moveall" % (src_dir,))
             continue
         remaining_items = lib.items(library.PathQuery('path', src_dir))
         if next(iter(remaining_items), None):
-            print "some Beets items left in %s, will not moveall" % (src_dir,)
+            print("some Beets items left in %s, will not moveall" % (src_dir,))
         elif os.path.exists(src_dir):
-            print "moving all leftovers in %s to %s" % (src_dir, dst_dir)
+            print("moving all leftovers in %s to %s" % (src_dir, dst_dir))
             for dirent in os.listdir(src_dir):
                 dirent_path = os.path.join(src_dir, dirent)
                 try:
-                    shutil.move(dirent_path, dst_dir)
-                except shutil.Error, ex:
+                    shutil.move(util.py3_path(dirent_path), util.py3_path(dst_dir))
+                except shutil.Error as ex:
                     # Log it but move on.
-                    # XXX unicode problem here if path has non-ascii
-                    log.critical("failed to move {0} to {1}: {2}", dirent_path,
-                                 dst_dir, ex)
+                    log.critical("failed to move {0} to {1}: {2}",
+                                 util.py3_path(dirent_path),
+                                 util.py3_path(dst_dir),
+                                 ex)
             util.prune_dirs(src_dir)


### PR DESCRIPTION
This should, as far as I can see, not hamper python2 compatibility.  But
Python2 is no longer supported starting from 2020-01-01, anyway...

Changes:
- iteritems -> items
- print statement -> function call
- proper handling of local exception var
- use util.py3_path on internal bytes paths where necessary

shutil.move must not be called w/ bytes paths, as it calls
path.rstrip(sep) on a passed path, where sep is a string.

Apparently, beets calls the event handlers with (discouraged, but
internally-used) bytes "paths" instead of unicode strings, presumably a
python2 legacy.